### PR TITLE
Add ceph python libs

### DIFF
--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -10,10 +10,13 @@ ARG GIT_REF
 ARG GIT_REF_REPO=https://git.openstack.org/openstack/${PROJECT}
 
 RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
+    && apt-key adv --fetch-keys "http://download.ceph.com/keys/release.asc" \
+    && echo "deb http://download.ceph.com/debian-jewel jessie main" > /etc/apt/sources.list.d/ceph.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
 # Project specific packages start
-		python \
+        python \
+        python-rados \
 # Project specific packages end
     && apt-get install -y --no-install-recommends ca-certificates curl git \
 # common install start
@@ -37,7 +40,7 @@ RUN set -x \
     && python get-pip.py \
     && rm get-pip.py \
     && pip install virtualenv \
-    && virtualenv /virtualenv \
+    && virtualenv --system-site-packages /virtualenv \
     && hash -r \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && groupadd -g 42424 ${PROJECT} \

--- a/dockerfiles/Dockerfile-ubuntu
+++ b/dockerfiles/Dockerfile-ubuntu
@@ -11,7 +11,7 @@ ARG GIT_REF_REPO=https://git.openstack.org/openstack/${PROJECT}
 
 RUN set -x \
     && apt-key adv --fetch-keys "http://download.ceph.com/keys/release.asc" \
-    && echo "deb http://download.ceph.com/debian-jewel jessie main" > /etc/apt/sources.list.d/ceph.list \
+    && echo "deb http://download.ceph.com/debian-jewel xenial main" > /etc/apt/sources.list.d/ceph.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
 # Project specific packages start

--- a/dockerfiles/Dockerfile-ubuntu
+++ b/dockerfiles/Dockerfile-ubuntu
@@ -10,10 +10,13 @@ ARG GIT_REF
 ARG GIT_REF_REPO=https://git.openstack.org/openstack/${PROJECT}
 
 RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
+    && apt-key adv --fetch-keys "http://download.ceph.com/keys/release.asc" \
+    && echo "deb http://download.ceph.com/debian-jewel jessie main" > /etc/apt/sources.list.d/ceph.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
 # Project specific packages start
-		python \
+        python \
+        python-rados \
 # Project specific packages end
     && apt-get install -y --no-install-recommends ca-certificates curl git \
 # common install start
@@ -37,7 +40,7 @@ RUN set -x \
     && python get-pip.py \
     && rm get-pip.py \
     && pip install virtualenv \
-    && virtualenv /virtualenv \
+    && virtualenv --system-site-packages /virtualenv \
     && hash -r \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && groupadd -g 42424 ${PROJECT} \


### PR DESCRIPTION
We have to update the virtualenv to allow it access to the system
python packages to access python-ceph. According to the ceph-devs, in
the next release of Ceph (Kraken) the python libs will be published to
PyPI. That is expected any day now.